### PR TITLE
feat(gen): support multi-locale SDKs

### DIFF
--- a/main.go
+++ b/main.go
@@ -57,9 +57,24 @@ type contentModelResponse struct {
 	Items []contentfulModel `json:"items"`
 }
 
+type contentfulLocale struct {
+	Name         string `json:"name"`
+	InternalCode string `json:"internal_code"`
+	Code         string `json:"code"`
+	Default      bool   `json:"default"`
+}
+
+type localeResponse struct {
+	Total int
+	Skip  int
+	Limit int
+	Items []contentfulLocale `json:"items"`
+}
+
 var (
-	models []contentfulModel
-	certs  string
+	models  []contentfulModel
+	locales = []string{}
+	certs   string
 )
 
 // contentful api endpoints
@@ -67,27 +82,79 @@ const cdaEndpoint = "cdn.contentful.com"
 const cmaEndpoint = "api.contentful.com"
 const cpaEndpoint = "preview.contentful.com"
 
-func init() {
-	var url = fmt.Sprintf("https://%s/spaces/%s/content_types?access_token=%s", cmaEndpoint, os.Getenv("CONTENTFUL_SPACE_ID"), os.Getenv("CONTENTFUL_AUTH_TOKEN"))
+func fetchModels() ([]contentfulModel, error) {
+	var url = fmt.Sprintf(
+		"https://%s/spaces/%s/content_types?access_token=%s",
+		cmaEndpoint,
+		os.Getenv("CONTENTFUL_SPACE_ID"),
+		os.Getenv("CONTENTFUL_AUTH_TOKEN"),
+	)
 	resp, err := http.Get(url)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 
+	// TODO paginate model responses, if necessary
 	var data contentModelResponse
 	bs, _ := ioutil.ReadAll(resp.Body)
 	if err := json.Unmarshal(bs, &data); err != nil {
-		log.Fatal(err.Error())
+		return nil, err
 	}
 	if err := resp.Body.Close(); err != nil {
-		log.Fatal(err.Error())
+		return nil, err
 	}
 
-	models = data.Items
+	return data.Items, nil
+}
 
+func fetchLocales() ([]contentfulLocale, error) {
+	var url = fmt.Sprintf(
+		"https://%s/spaces/%s/locales",
+		cmaEndpoint,
+		os.Getenv("CONTENTFUL_SPACE_ID"),
+	)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", os.Getenv("CONTENTFUL_CMA_TOKEN")))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO paginate model responses, if necessary
+	var data localeResponse
+	bs, _ := ioutil.ReadAll(resp.Body)
+	if err := json.Unmarshal(bs, &data); err != nil {
+		return nil, err
+	}
+	if err := resp.Body.Close(); err != nil {
+		return nil, err
+	}
+
+	return data.Items, nil
+}
+
+func init() {
+	var err error
+	models, err = fetchModels()
+	if err != nil {
+		log.Fatal(err)
+	}
 	for i := range models {
 		models[i].Name = strings.Replace(models[i].Name, " ", "", -1)
 	}
+
+	cfLocales, err := fetchLocales()
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, l := range cfLocales {
+		locales = append(locales, l.Code)
+	}
+
+	fmt.Printf("%#v\n", locales)
 
 	certs, err = fetchCerts()
 	if err != nil {


### PR DESCRIPTION
this PR adds support for multi-locale SDKs.

specifically, it allows a user to pass `*` as a locale on generation time, and it will then generate structs with fields for every supported language.

see https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/localization/retrieve-localized-entries