### PR TITLE
fix(model): Keep the order of 1:n lists by reversing the id traversal

### DIFF
--- a/model.go
+++ b/model.go
@@ -454,13 +454,17 @@ func generateModelType(f *jen.File, m contentfulModel) {
 		jen.Id("cache").Id("*iteratorCache"),
 	).Index().Id(m.Name).Block(
 		jen.Var().Id("items").Index().Id(m.Name),
-		jen.For(jen.List(jen.Id("_"), jen.Id("entry")).Op(":=").Range().Append(jen.Id("includes.Entries"), jen.Id("its..."))).Block(
+		jen.Id("entries").Op(":=").Append(jen.Id("includes.Entries"), jen.Id("its...")),
+		jen.For(jen.List(jen.Id("_"), jen.Id("entryID")).Op(":=").Range().Id("ids")).Block(
 			jen.Var().Id("item").Id(fmt.Sprintf("%sItem", m.DowncasedName())),
-			jen.Var().Id("included").Op("=").Lit(false),
-			jen.For(jen.List(jen.Id("_"), jen.Id("entryID")).Op(":=").Range().Id("ids")).Block(
-				jen.Id("included").Op("=").Id("included").Op("||").Id("entryID.Sys.ID").Op("==").Id("entry.Sys.ID"),
+			jen.Var().Id("entry").Op("*").Id("includeEntry"),
+			jen.For(jen.List(jen.Id("_"), jen.Id("e")).Op(":=").Range().Id("entries")).Block(
+				jen.If(jen.Id("e.Sys.ID").Op("==").Id("entryID.Sys.ID")).Block(
+					jen.Id("entry").Op("=").Op("&").Id("e"),
+					jen.Break(),
+				),
 			),
-			jen.If(jen.Id("included").Op("!=").Lit(true)).Block(
+			jen.If(jen.Id("entry").Op("==").Nil()).Block(
 				jen.Continue(),
 			),
 			jen.If(


### PR DESCRIPTION
Before this commits the list of related entries was collected by traversing the included entries which does not care about the order of the ids coming from the contentful API, in fact using this approach the related entries were sorted by id. This commit changes the approach to iterate over the entryIDs of the relation field that has the 1:n related entries. Quite an easy fix with a big feature, since content editors will expect lists to be in the order arranged in contentful when viewing on the using website/app.