### PR TITLE
Add support for environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ generate a complete contentful SDK client from your existing schema
 - [x] generates typed contentful content management api SDK
 - [x] supports recursive type definitions
 - [x] supports assets
+- [x] supports multiple environments
 
 ## Installation
 
@@ -26,6 +27,7 @@ first, export the necessary credentials into your env:
 
 ```
 $ export CONTENTFUL_SPACE_ID=awesome-space
+$ export CONTENTFUL_ENVIRONMENT=staging
 $ export CONTENTFUL_AUTH_TOKEN=secret-token
 ```
 

--- a/client.go
+++ b/client.go
@@ -85,6 +85,7 @@ func generateContentClient(f *jen.File) {
 		jen.Id("spaceID").String(),
 		jen.Id("authToken").String(),
 		jen.Id("Locale").String(),
+		jen.Id("environment").String(),
 		jen.Id("client").Op("*").Qual("net/http", "Client"),
 		jen.Id("pool").Op("*").Qual("crypto/x509", "CertPool"),
 	)
@@ -102,15 +103,17 @@ func generateContentClient(f *jen.File) {
 	f.Func().Id("NewCDA").Params(
 		jen.Id("authToken").String(),
 		jen.Id("locale").String(),
+		jen.Id("environment").String(),
 	).Op("*").Id("ContentClient").Block(
 		jen.Id("pool").Op(":=").Qual("crypto/x509", "NewCertPool").Call(),
 		jen.Id("pool").Dot("AppendCertsFromPEM").Call(jen.Index().Byte().Parens(jen.Lit(certs))),
 		jen.Return(jen.Op("&").Id("ContentClient").Values(jen.Dict{
-			jen.Id("host"):      jen.Qual("fmt", "Sprintf").Params(jen.Lit("https://%s"), jen.Id("contentfulCDAURL")),
-			jen.Id("spaceID"):   jen.Lit(os.Getenv("CONTENTFUL_SPACE_ID")),
-			jen.Id("authToken"): jen.Id("authToken"),
-			jen.Id("Locale"):    jen.Id("locale"),
-			jen.Id("pool"):      jen.Id("pool"),
+			jen.Id("host"):        jen.Qual("fmt", "Sprintf").Params(jen.Lit("https://%s"), jen.Id("contentfulCDAURL")),
+			jen.Id("spaceID"):     jen.Lit(os.Getenv("CONTENTFUL_SPACE_ID")),
+			jen.Id("authToken"):   jen.Id("authToken"),
+			jen.Id("Locale"):      jen.Id("locale"),
+			jen.Id("environment"): jen.Id("environment"),
+			jen.Id("pool"):        jen.Id("pool"),
 			jen.Id("client"): jen.Op("&").Qual("net/http", "Client").Values(jen.Dict{
 				jen.Id("Transport"): jen.Op("&").Qual("net/http", "Transport").Values(jen.Dict{
 					jen.Id("TLSClientConfig"): jen.Op("&").Qual("crypto/tls", "Config").Values(jen.Dict{
@@ -125,15 +128,17 @@ func generateContentClient(f *jen.File) {
 	f.Func().Id("NewCPA").Params(
 		jen.Id("authToken").String(),
 		jen.Id("locale").String(),
+		jen.Id("environment").String(),
 	).Op("*").Id("ContentClient").Block(
 		jen.Id("pool").Op(":=").Qual("crypto/x509", "NewCertPool").Call(),
 		jen.Id("pool").Dot("AppendCertsFromPEM").Call(jen.Index().Byte().Parens(jen.Lit(certs))),
 		jen.Return(jen.Op("&").Id("ContentClient").Values(jen.Dict{
-			jen.Id("host"):      jen.Qual("fmt", "Sprintf").Params(jen.Lit("https://%s"), jen.Id("contentfulCPAURL")),
-			jen.Id("spaceID"):   jen.Lit(os.Getenv("CONTENTFUL_SPACE_ID")),
-			jen.Id("authToken"): jen.Id("authToken"),
-			jen.Id("Locale"):    jen.Id("locale"),
-			jen.Id("pool"):      jen.Id("pool"),
+			jen.Id("host"):        jen.Qual("fmt", "Sprintf").Params(jen.Lit("https://%s"), jen.Id("contentfulCPAURL")),
+			jen.Id("spaceID"):     jen.Lit(os.Getenv("CONTENTFUL_SPACE_ID")),
+			jen.Id("authToken"):   jen.Id("authToken"),
+			jen.Id("Locale"):      jen.Id("locale"),
+			jen.Id("environment"): jen.Id("environment"),
+			jen.Id("pool"):        jen.Id("pool"),
 			jen.Id("client"): jen.Op("&").Qual("net/http", "Client").Values(jen.Dict{
 				jen.Id("Transport"): jen.Op("&").Qual("net/http", "Transport").Values(jen.Dict{
 					jen.Id("TLSClientConfig"): jen.Op("&").Qual("crypto/tls", "Config").Values(jen.Dict{

--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ const cmaEndpoint = "api.contentful.com"
 const cpaEndpoint = "preview.contentful.com"
 
 func init() {
-	var url = fmt.Sprintf("https://%s/spaces/%s/content_types?access_token=%s", cmaEndpoint, os.Getenv("CONTENTFUL_SPACE_ID"), os.Getenv("CONTENTFUL_AUTH_TOKEN"))
+	var url = fmt.Sprintf("https://%s/spaces/%s/environments/%s/content_types?access_token=%s", cmaEndpoint, os.Getenv("CONTENTFUL_SPACE_ID"), os.Getenv("CONTENTFUL_ENVIRONMENT"), os.Getenv("CONTENTFUL_AUTH_TOKEN"))
 	resp, err := http.Get(url)
 	if err != nil {
 		log.Fatal(err)

--- a/model.go
+++ b/model.go
@@ -283,9 +283,10 @@ func generateModelType(f *jen.File, m contentfulModel) {
 	).Id("fetch").Params().Id("error").Block(
 		jen.Id("c").Op(":=").Id("it.c"),
 		jen.Var().Id("url").Op("=").Qual("fmt", "Sprintf").Params(
-			jen.Lit("%s/spaces/%s/entries?access_token=%s&content_type=%s&include=%d&locale=%s&limit=%d&skip=%d"),
+			jen.Lit("%s/spaces/%s/environments/%s/entries?access_token=%s&content_type=%s&include=%d&locale=%s&limit=%d&skip=%d"),
 			jen.Id("c.host"),
 			jen.Id("c.spaceID"),
+			jen.Id("c.environment"),
 			jen.Id("c.authToken"),
 			jen.Lit(m.Sys.ID),
 			jen.Id("it.IncludeCount"),


### PR DESCRIPTION
Left it up for user to specify which environment in `NewCDA` and `NewCPA` even though it is possible to have incompatible model schema across environments.

Left `NewManagement` as is, since content management API has global scope.